### PR TITLE
Improve validation in compute sample similarity() in similarity.py

### DIFF
--- a/src/sample_similarity_explorer/similarity.py
+++ b/src/sample_similarity_explorer/similarity.py
@@ -19,20 +19,54 @@ def compute_sample_similarity(df: pd.DataFrame, metric: str = "pearson") -> pd.D
         Sample-by-sample similarity matrix.
     """
 
+    # Added: basic input type validation
+    if not isinstance(df, pd.DataFrame):
+        raise ValueError("Input must be a pandas DataFrame.")
+
     if df.empty:
         raise ValueError("Input dataframe is empty.")
+
+    # Added: require at least two samples
+    if df.shape[1] < 2:
+        raise ValueError("At least two samples are required to compute similarity.")
+
+    # Added: detect all-missing sample columns before dropping rows
+    all_missing_samples = df.columns[df.isna().all(axis=0)].tolist()
+    if all_missing_samples:
+        raise ValueError(
+            f"Samples with all missing values are not allowed: {all_missing_samples}"
+        )
+
+    # Added: numeric validation
+    numeric_df = df.apply(pd.to_numeric, errors="coerce")
+    original_missing = df.isna()
+    invalid_values = numeric_df.isna() & ~original_missing
+    if invalid_values.any().any():
+        bad_rows, bad_cols = invalid_values.to_numpy().nonzero()
+        first_bad_row = df.index[bad_rows[0]]
+        first_bad_col = df.columns[bad_cols[0]]
+        bad_value = df.loc[first_bad_row, first_bad_col]
+        raise ValueError(
+            f"Non-numeric value found in dataframe at feature '{first_bad_row}', "
+            f"sample '{first_bad_col}': {bad_value!r}"
+        )
         
     df = df.dropna(axis=0, how="any")
 
-    if metric not in {"pearson", "cosine"}:
-        raise ValueError(f"Unsupported metric: {metric}")
-
-    data = df.values.T  # samples x features
+    # Added: check whether any usable rows remain
+    if df.empty:
+        raise ValueError("No valid features remain after removing rows with missing values.")
     
     if metric not in {"pearson", "cosine"}:
         raise ValueError(f"Unsupported metric: {metric}")
 
     data = df.values.T  # samples x features
+
+    # Added: define clear behavior for constant-valued samples in Pearson
+    if metric == "pearson":
+        constant_samples = [col for col in df.columns if df[col].nunique() <= 1]
+        if constant_samples:
+            raise ValueError(f"Pearson correlation cannot be computed for constant-valued samples: {constant_samples}")
 
     if metric == "pearson":
         sim = np.corrcoef(data)
@@ -42,4 +76,50 @@ def compute_sample_similarity(df: pd.DataFrame, metric: str = "pearson") -> pd.D
         sim = normalized @ normalized.T
 
     return pd.DataFrame(sim, index=df.columns, columns=df.columns)
+
+
+def get_top_similar_samples(
+    similarity_df: pd.DataFrame,
+    reference_sample: str,
+    top_n: int = 5,
+    exclude_self: bool = True,
+) -> pd.DataFrame:
+    """
+    Return the top N most similar samples to a reference sample.
+    """
+
+    # Added: basic validation
+    if not isinstance(similarity_df, pd.DataFrame):
+        raise ValueError("similarity_df must be a pandas DataFrame.")
+
+    if similarity_df.empty:
+        raise ValueError("similarity_df is empty.")
+
+    if similarity_df.shape[0] != similarity_df.shape[1]:
+        raise ValueError("similarity_df must be a square matrix.")
+
+    if list(similarity_df.index) != list(similarity_df.columns):
+        raise ValueError(
+            "similarity_df must have matching row and column labels in the same order."
+        )
+
+    if reference_sample not in similarity_df.index:
+        raise ValueError(f"Reference sample not found: {reference_sample}")
+
+    if not isinstance(top_n, int) or top_n <= 0:
+        raise ValueError("top_n must be a positive integer.")
+
+    scores = similarity_df.loc[reference_sample].copy()
+
+    if exclude_self:
+        scores = scores.drop(labels=[reference_sample], errors="ignore")
+
+    scores = scores.sort_values(ascending=False).head(top_n)
+
+    return pd.DataFrame(
+        {
+            "sample": scores.index,
+            "similarity": scores.values,
+        }
+    ).reset_index(drop=True)
 


### PR DESCRIPTION
Improve validation in compute_sample_similarity() in similarity.py, adding additional checks before computing similarity:

1. Ensure at least two samples are present

2. Detect all-missing sample columns

3. Define clear behavior for constant-valued samples when using Pearson correlation

4. Raise informative error messages for invalid inputs




Add get_top_similar_samples(similarity_df, reference_sample, top_n=5, exclude_self=True):

1. Return the **top N most similar samples** to a given reference sample

2. Sort results by similarity score

3. Optionally exclude the reference sample itself from the results

4. Raise an error if the **reference sample does not exist**

5. Raise an error if **top_n is invalid** (e.g., negative or zero)

6. Validate that the similarity matrix is square and correctly labeled